### PR TITLE
add boot key interval

### DIFF
--- a/k3os-proxmox.json
+++ b/k3os-proxmox.json
@@ -54,6 +54,7 @@
       ],
       "http_directory":"http",
       "boot_wait": "{{ user `boot_wait`}}",
+      "boot_key_interval": "20ms",
       "boot_command": [
          "e<down><down><down><down><down><down><down><left>",
          " ssh_authorized_keys=\"{{ user `authorized_keys` }}\" boot_cmd=\"echo GA_PATH=/dev/vport2p1>/etc/conf.d/qemu-guest-agent\"<F10>"


### PR DESCRIPTION
the latest packer upgrade has the boot keys sending very fast - a great improvement, actually!

But, the default timing sends the keys too fast and eventually corrupts inputs to be interpreted in all caps